### PR TITLE
Compile/use later versions of PHP (e.g. 5.5 or 5.6)

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -14,7 +14,6 @@
     - geerlingguy.nginx
     - geerlingguy.mysql
     - geerlingguy.php
-    - geerlingguy.php-mysql
     - geerlingguy.composer
     - geerlingguy.drush
 
@@ -25,6 +24,11 @@
         dest: /etc/nginx/sites-enabled/drupal.conf
         mode: 0644
       notify: restart nginx
+
+    - name: Ensure php5-fpm www pool configuration directory exists.
+      file:
+        path: /etc/php5/fpm/pool.d
+        state: directory
 
     - name: Copy php5-fpm www pool configuration into place.
       template:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ geerlingguy.git
 geerlingguy.mysql
 geerlingguy.nginx
 geerlingguy.php
-geerlingguy.php-mysql

--- a/tasks/drupal.yml
+++ b/tasks/drupal.yml
@@ -21,9 +21,15 @@
     group: www-data
 
 # Generate Drupal codebase with makefile.
+- name: Copy drush makefile into place.
+  copy:
+    src: "{{ drush_makefile_path }}"
+    dest: /tmp/drupal.make.yml
+  when: drupal_site.stat.exists == false
+
 - name: Generate Drupal site with drush makefile.
   command: >
-    {{ drush_path }} make -y {{ drush_makefile_path }}
+    {{ drush_path }} make -y /tmp/drupal.make.yml
     chdir={{ drupal_core_path }}
   when: drupal_site.stat.exists == false
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -50,23 +50,55 @@ mysql_databases:
   }
 
 # PHP configuration.
+php_install_from_source: true
+# Some example versions to try: php-5.5.26, php-5.6.10, php-7.0.0alpha2.
+php_source_version: "php-5.6.10"
+php_source_make_command: "make --jobs={{ ansible_processor_count }}"
+php_source_configure_command: >
+  ./configure
+  --prefix={{ php_source_install_path }}
+  --with-config-file-path={{ php_conf_path }}
+  --with-config-file-scan-dir={{ php_conf_path }}/conf.d
+  --enable-mbstring
+  --enable-zip
+  --enable-bcmath
+  --enable-pcntl
+  --enable-ftp
+  --enable-fpm
+  --enable-exif
+  --enable-calendar
+  --enable-opcache
+  --enable-pdo
+  --enable-sysvmsg
+  --enable-sysvsem
+  --enable-sysvshm
+  --enable-wddx
+  --with-curl
+  --with-mcrypt
+  --with-iconv
+  --with-gmp
+  --with-pspell
+  --with-gd
+  --with-jpeg-dir=/usr
+  --with-png-dir=/usr
+  --with-zlib-dir=/usr
+  --with-xpm-dir=/usr
+  --with-freetype-dir=/usr
+  --enable-gd-native-ttf
+  --enable-gd-jis-conv
+  --with-openssl
+  --with-pdo-mysql=/usr
+  --with-gettext=/usr
+  --with-zlib=/usr
+  --with-bz2=/usr
+  --with-recode=/usr
+  --with-mysqli=/usr/bin/mysql_config
 php_webserver_daemon: "nginx"
-php_packages:
-  - php5
-  - php5-fpm
-  - php5-cli
-  - php5-common
-  - php5-curl
-  - php5-dev
-  - php5-gd
-  - php5-mcrypt
-  - php-pear
-  - php-apc
 php_enable_php_fpm: true
 php_memory_limit: "128M"
 php_max_execution_time: "240"
-php_apc_enabled_in_ini: true
-php_apc_stat: "0"
+php_opcache_enabled_in_ini: true
+php_opcache_memory_consumption: "128"
 
 # Drush configuration.
 drush_version: "master"


### PR DESCRIPTION
This PR attempts to allow any version of PHP to be used on the Raspberry Pi (even including PHP 7 releases), by compiling PHP from source rather than installing via Debian's packages.

Drupal 8 will soon [require PHP 5.5](https://www.drupal.org/node/2296557), and [suggest PHP 5.6](https://www.drupal.org/node/2524432), and seeing that Debian Wheezy only officially supports 5.4.x in Pi/arm-compatible repos (see https://github.com/geerlingguy/raspberry-pi-dramble/issues/51), compilation seems to be the only viable option for the Pi, until newer versions are available in Raspbian's default configuration.